### PR TITLE
"Review Payment" button should read "Send Payment"

### DIFF
--- a/extension/html/en.html
+++ b/extension/html/en.html
@@ -1,5 +1,4 @@
 
-
 <!DOCTYPE html>
 <html>
 <head>
@@ -1433,7 +1432,7 @@
             </div>
 
             <div class="form-actions">
-                <button class="send btn btn-primary pop" title="Review Payment" data-content="Click Here to review payment. You will be able to confirm or cancel the transaction.">Review Payment</button>
+                <button class="send btn btn-primary pop" title="Send Payment" data-content="Click Here to send payment.">Send Payment</button>
 
                 <p class="help-block send-options" style="padding-top:10px">
                     <b>Maximum Send Value:</b> <span></span><br />


### PR DESCRIPTION
In the **Shared Coin** view, when a user clicks on the **Review Payment** button, the transaction is immediately initiated.  The dialog has a **Cancel** button, but it is disabled.  Updating UI to match actual behavior.
